### PR TITLE
Left and Right spaces fixed

### DIFF
--- a/app/src/main/java/net/studymongolian/fontmetrics/FontMetricsView.java
+++ b/app/src/main/java/net/studymongolian/fontmetrics/FontMetricsView.java
@@ -148,7 +148,7 @@ public class FontMetricsView extends View {
             mTextPaint.getTextBounds(mText, 0, mText.length(), mBounds);
 
             // draw vertical line just before the left bounds
-            startX = getPaddingLeft() + mBounds.left - (width - mBounds.width())/2;
+            startX = getPaddingLeft();
             stopX = startX;
             startY = -verticalAdjustment;
             stopY = startY + this.getHeight();


### PR DESCRIPTION
I checked [SkPaint.cpp](https://github.com/google/skia/blob/master/src/core/SkPaint.cpp) and found that the left and right spaces does not balance.
They are decided by glyph of the head character and of the tail character, so you can draw the line at padding left position simply.